### PR TITLE
Add version 2025.11.001 to CABLE vers

### DIFF
--- a/spack_repo/access/nri/packages/cable/package.py
+++ b/spack_repo/access/nri/packages/cable/package.py
@@ -22,7 +22,7 @@ class Cable(CMakePackage):
     version("stable", branch="main", preferred=True)
     version("2025.11.001", tag="2025.11.001", commit="8769df1e65868414247c527ac2ec18979a7dbb67")
     version("2025.11.000", tag="2025.11.000", commit="15f639dd33dfb15819304332d72c2b405b51b85e")
-    
+
     variant(
         "mpi",
         default=True,

--- a/spack_repo/access/nri/packages/cable/package.py
+++ b/spack_repo/access/nri/packages/cable/package.py
@@ -21,7 +21,8 @@ class Cable(CMakePackage):
 
     version("stable", branch="main", preferred=True)
     version("2025.11.000", tag="2025.11.000", commit="15f639dd33dfb15819304332d72c2b405b51b85e")
-
+    version("2025.11.001", tag="2025.11.001", commit="8769df1e65868414247c527ac2ec18979a7dbb67")
+    
     variant(
         "mpi",
         default=True,

--- a/spack_repo/access/nri/packages/cable/package.py
+++ b/spack_repo/access/nri/packages/cable/package.py
@@ -20,8 +20,8 @@ class Cable(CMakePackage):
     license("LicenseRef-CSIRO-Open-Source-Software-License-v1.0", checked_by="anton-seaice")
 
     version("stable", branch="main", preferred=True)
-    version("2025.11.000", tag="2025.11.000", commit="15f639dd33dfb15819304332d72c2b405b51b85e")
     version("2025.11.001", tag="2025.11.001", commit="8769df1e65868414247c527ac2ec18979a7dbb67")
+    version("2025.11.000", tag="2025.11.000", commit="15f639dd33dfb15819304332d72c2b405b51b85e")
     
     variant(
         "mpi",


### PR DESCRIPTION
Adds the `2025.11.001` version for `cable`, which is the version which adds GCC support for the library build.