### PR TITLE
Add new access_fms and mom5 versions

### DIFF
--- a/spack_repo/access/nri/packages/access_fms/package.py
+++ b/spack_repo/access/nri/packages/access_fms/package.py
@@ -35,6 +35,13 @@ class AccessFms(CMakePackage):
         commit="bf5f05bbf817b0168773fb2737e9d707c989fb43"
     )
 
+    variant(
+        "build_type",
+        default="RelWithDebInfo",
+        sticky=True,
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo")
+    )
     variant("gfs_phys", default=False, sticky=True, description="Use GFS Physics")
     variant("large_file", default=False, sticky=True, description="Enable compiler definition -Duse_LARGEFILE.")
     variant(

--- a/spack_repo/access/nri/packages/mom5/package.py
+++ b/spack_repo/access/nri/packages/mom5/package.py
@@ -70,6 +70,12 @@ class Mom5(CMakePackage):
         description="Deterministic build"
     )
 
+    requires(
+        "build_type=Release",
+        when="+deterministic",
+        msg="Deterministic builds are only supported with build_type=Release",
+    )
+
     depends_on("c", type="build")
     depends_on("fortran", type="build")
     depends_on("cmake@3.18:", type="build")


### PR DESCRIPTION
This PR:
- `access_fms` SPR:
  - [x] adds a `build_type` variant now that compiler flags for `RelWithDebInfo` [are defined](https://github.com/ACCESS-NRI/FMS/pull/27)
  - [ ] adds version XXXX.XX.XXX
- `mom5` SPR:
  - [x] adds a conflict to only allow `+deterministic` with `build_type=Release` ([see discussion here](https://github.com/ACCESS-NRI/MOM5/pull/91#discussion_r3861287042))
  - [ ] adds version XXXX.XX.XXX