### PR TITLE
cice5: version-gate layout variants for runtime-configurable builds

### DIFF
--- a/spack_repo/access/nri/packages/cice5/package.py
+++ b/spack_repo/access/nri/packages/cice5/package.py
@@ -7,18 +7,6 @@
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack.package import *
 
-# These are the default layouts, inc 3 executables for OM2
-# alternatively, supply the 5 layout variants to produce 1 executable
-OM2_LAYOUTS = [
-        {"nxglob": "360", "nyglob": "300", "blckx": "15", "blcky": "300", "mxblcks": "1"},
-        {"nxglob": "1440", "nyglob": "1080", "blckx": "30", "blcky": "27", "mxblcks": "4"},
-        {"nxglob": "3600", "nyglob": "2700", "blckx": "40", "blcky": "30", "mxblcks": "12"},
-    ]
-ESM1P6_LAYOUTS = [
-    {"nxglob": "360", "nyglob": "300", "blckx": "30", "blcky": "300", "mxblcks": "1"},
-]
-
-
 def _int_validator(s):
     """Test a string variant is a valid integer"""
     if (s != "none"):
@@ -56,11 +44,14 @@ class Cice5(CMakePackage):
 
     variant("io_type", default="NetCDF", sticky=True, values=("NetCDF", "PIO"), description="CICE IO Method")
     # User set integer cmake options:
-    variant("nxglob", default="none", sticky=True, values=_int_validator, description="Size of model grid in x")
-    variant("nyglob", default="none", sticky=True, values=_int_validator, description="Size of model grid in y")
-    variant("blckx", default="none", sticky=True, values=_int_validator, description="Size of computational blocks in x")
-    variant("blcky", default="none", sticky=True, values=_int_validator, description="Size of computational blocks in y")
-    variant("mxblcks", default="none", sticky=True, values=_int_validator, description="Max number of blocks per task")
+    # From cice5 PR#113, these become runtime domain_nml settings and the
+    # matching CMake cache variables are removed, so the variants no longer
+    # apply once the layout is decided at run time.
+    variant("nxglob", default="none", sticky=True, values=_int_validator, description="Size of model grid in x", when="@:2026.07")
+    variant("nyglob", default="none", sticky=True, values=_int_validator, description="Size of model grid in y", when="@:2026.07")
+    variant("blckx", default="none", sticky=True, values=_int_validator, description="Size of computational blocks in x", when="@:2026.07")
+    variant("blcky", default="none", sticky=True, values=_int_validator, description="Size of computational blocks in y", when="@:2026.07")
+    variant("mxblcks", default="none", sticky=True, values=_int_validator, description="Max number of blocks per task", when="@:2026.07")
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")
@@ -92,7 +83,6 @@ class Cice5(CMakePackage):
     phases = ["set_layouts", "cmake", "build", "install"]
 
     _all_layouts = [{}]  # all layouts to build,
-    # see OM2_LAYOUTS and ESM1P6_LAYOUTS for examples
     _layout = {}  # current layout being setup/built/installed
 
     def cmake_args(self):
@@ -105,12 +95,18 @@ class Cice5(CMakePackage):
         else:  # access-om2
             args = [self.define("CICE_DRIVER", "auscom")]
 
+        # From cice5 PR#113, nxglob/nyglob/blckx/blcky/mxblcks become runtime
+        # domain_nml settings and the matching CMake cache variables go away.
+        if self.spec.satisfies("@:2026.07"):
+            args.extend([
+                self.define("CICE_NXGLOB", self._layout['nxglob']),
+                self.define("CICE_NYGLOB", self._layout['nyglob']),
+                self.define("CICE_BLCKX", self._layout['blckx']),
+                self.define("CICE_BLCKY", self._layout['blcky']),
+                self.define("CICE_MXBLCKS", self._layout['mxblcks']),
+            ])
+
         args.extend([
-            self.define("CICE_NXGLOB", self._layout['nxglob']),
-            self.define("CICE_NYGLOB", self._layout['nyglob']),
-            self.define("CICE_BLCKX", self._layout['blckx']),
-            self.define("CICE_BLCKY", self._layout['blcky']),
-            self.define("CICE_MXBLCKS", self._layout['mxblcks']),
             self.define_from_variant("CICE_IO", "io_type"),
             self.define_from_variant("CICE_DETERMINISTIC", "deterministic"),
         ])
@@ -119,9 +115,11 @@ class Cice5(CMakePackage):
 
     @property
     def build_dirname(self) -> str:
-        """Directory name to use when building the package. 
+        """Directory name to use when building the package.
         We modify this using _layout to ensure uniqueness with multiple builds
         """
+        if not self._layout:
+            return super().build_dirname
         build = (
             f"{self._layout['nxglob']}x{self._layout['nyglob']}_"
             f"{self._layout['blckx']}x{self._layout['blcky']}_"
@@ -130,31 +128,48 @@ class Cice5(CMakePackage):
         return f"{super().build_dirname}/{build}"
 
     def set_layouts(self, spec, prefix):
-        """Layout of cice processors to use. If variants are set, use those. 
+        """Layout of cice processors to use. If variants are set, use those.
         Otherwise, use defaults."""
-        layout_variants = OM2_LAYOUTS[0].keys()
 
-        # if all 5 layouts variants are available, set the layouts dict
-        if all([
-            self.spec.variants[variant].value != 'none' 
-            for variant in layout_variants
-        ]):
-            layouts = [{variant: self.spec.variants[variant].value
-                for variant in layout_variants}]
-        # else if no layout variants are available, use the defaults
-        elif all([
-            self.spec.variants[variant].value == 'none' 
-            for variant in layout_variants
-        ]):
-            if self.spec.variants["model"].value == "access-esm1.6":
-                layouts = ESM1P6_LAYOUTS
+        # From cice5 PR#113, the layout variants only exist for @:2026.07 -
+        # later versions decide the layout at run time via domain_nml, so a
+        # single build with no compile-time layout is enough.
+        if self.spec.satisfies("@:2026.07"):
+
+            # These are the default layouts, inc 3 executables for OM2
+            # alternatively, supply the 5 layout variants to produce 1 executable
+            OM2_LAYOUTS = [
+                    {"nxglob": "360", "nyglob": "300", "blckx": "15", "blcky": "300", "mxblcks": "1"},
+                    {"nxglob": "1440", "nyglob": "1080", "blckx": "30", "blcky": "27", "mxblcks": "4"},
+                    {"nxglob": "3600", "nyglob": "2700", "blckx": "40", "blcky": "30", "mxblcks": "12"},
+                ]
+            ESM1P6_LAYOUTS = [
+                {"nxglob": "360", "nyglob": "300", "blckx": "30", "blcky": "300", "mxblcks": "1"},
+            ]
+
+            layout_variants = OM2_LAYOUTS[0].keys()
+
+            # if all 5 layouts variants are available, set the layouts dict
+            if all([
+                self.spec.variants[variant].value != 'none'
+                for variant in layout_variants
+            ]):
+                layouts = [{variant: self.spec.variants[variant].value
+                    for variant in layout_variants}]
+            # else if no layout variants are available, use the defaults
+            elif all([
+                self.spec.variants[variant].value == 'none'
+                for variant in layout_variants
+            ]):
+                if self.spec.variants["model"].value == "access-esm1.6":
+                    layouts = ESM1P6_LAYOUTS
+                else:
+                    layouts = OM2_LAYOUTS
             else:
-                layouts = OM2_LAYOUTS
-        else:
-            raise Error(f"All of {layout_variants} "
-                        "variants must be set if any are set")
+                raise Error(f"All of {layout_variants} "
+                            "variants must be set if any are set")
 
-        self._all_layouts = layouts
+            self._all_layouts = layouts
 
     def cmake(self, spec, prefix):
         for layout in self._all_layouts:


### PR DESCRIPTION
Closes #489

## Summary

From [cice5 PR#113](https://github.com/ACCESS-NRI/cice5/pull/113), CICE5's grid/block layout (`nxglob`, `nyglob`, `blckx`, `blcky`, `mxblcks`) becomes a runtime `domain_nml` setting instead of a build-time one, and the matching `CICE_NXGLOB`/`CICE_NYGLOB`/`CICE_BLCKX`/`CICE_BLCKY`/`CICE_MXBLCKS` CMake cache variables go away. This means only one executable is needed per model/IO configuration instead of three (previously `access-om2` built three separate `cice_auscom.exe` layouts).

As proposed in #489, the existing layout-variant behaviour is kept for current versions (`@:2026.07`), and simplified for future versions (`@2026.08:`):

- The five layout variants (`nxglob`, `nyglob`, `blckx`, `blcky`, `mxblcks`) now only exist `when="@:2026.07"`.
- `cmake_args()` only passes the `CICE_*` layout defines for `@:2026.07`.
- `set_layouts()` only builds the multi-layout `OM2_LAYOUTS`/`ESM1P6_LAYOUTS` lists for `@:2026.07`; later versions fall back to the class default `_all_layouts = [{}]` (a single build).
- `build_dirname` falls back to the default build directory when `_layout` is empty.

## Testing

Tested locally on Gadi by pinning `cice5` to PR#113's branch head (`@git.345d1fba9ab4b7c01aa556f310094c7831e931f3=2026.08.000`) in an `access-om2` spack environment. `spack install` succeeds and produces a single `cice_auscom.exe` (vs. three previously). Existing tagged versions (`2026.07.000`, `2026.01.000`) are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
