### PR TITLE
gcom: support %oneapi

### DIFF
--- a/spack_repo/access/nri/packages/gcom/package.py
+++ b/spack_repo/access/nri/packages/gcom/package.py
@@ -46,6 +46,8 @@ class Gcom(Package):
         """
         if spec.satisfies("%intel"):
             mach_c = "ifort"
+        elif spec.satisfies("%oneapi"):
+            mach_c = "oneapi"
         elif spec.satisfies("%gcc"):
             mach_c = "gfortran"
         else:


### PR DESCRIPTION
Needed to support `%oneapi` compilers.
Blocked till the oneapi cfg is added to ACCESSS-NRI `gcom` source repository.